### PR TITLE
feat: make filename editable when uploading, default to file's name

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 lib
 lint-staged.config.js
 package.config.ts
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hups-co/sanity-plugin-mux-input",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hups-co/sanity-plugin-mux-input",
-      "version": "2.3.6",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@mux/mux-player-react": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "sanity-plugin-mux-input",
+  "name": "@hups-co/sanity-plugin-mux-input",
   "version": "2.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sanity-plugin-mux-input",
+      "name": "@hups-co/sanity-plugin-mux-input",
       "version": "2.3.6",
       "license": "MIT",
       "dependencies": {
@@ -15274,10 +15274,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -19101,10 +19102,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -23740,10 +23742,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -24450,10 +24453,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hups-co/sanity-plugin-mux-input",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "description": "An input component that integrates Sanity Studio with Mux video encoding/hosting service.",
   "keywords": [
     "sanity",

--- a/src/actions/upload.ts
+++ b/src/actions/upload.ts
@@ -79,7 +79,7 @@ export function uploadFile({
   settings,
   client,
   file,
-  filename = file.name
+  filename = file.name,
 }: {
   settings: MuxNewAssetSettings
   client: SanityClient
@@ -257,12 +257,12 @@ export function testUrl(url: string): Observable<string> {
   return of(url)
 }
 
-function optionsFromFile(opts: {preserveFilename?: boolean}, file: File, filename?:string) {
+function optionsFromFile(opts: {preserveFilename?: boolean}, file: File, filename?: string) {
   if (typeof window === 'undefined' || !(file instanceof window.File)) {
     return undefined
   }
   return {
-    name: opts.preserveFilename === false ? undefined : (filename ?? file.name),
+    name: opts.preserveFilename === false ? undefined : filename ?? file.name,
     type: file.type,
   }
 }

--- a/src/components/PlayerActionsMenu.tsx
+++ b/src/components/PlayerActionsMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  EditIcon,
   EllipsisHorizontalIcon,
   EllipsisVerticalIcon,
   LockIcon,
@@ -94,6 +95,16 @@ function PlayerActionsMenu(
         animate
         content={
           <Menu ref={setMenuRef}>
+            <Box padding={2}>
+              <Label muted size={1}>
+                Edit
+              </Label>
+            </Box>
+            <MenuItem
+              icon={EditIcon}
+              text="Details"
+              onClick={() => setDialogState('edit-video')}
+            />
             <Box padding={2}>
               <Label muted size={1}>
                 Replace

--- a/src/components/PlayerActionsMenu.tsx
+++ b/src/components/PlayerActionsMenu.tsx
@@ -100,11 +100,7 @@ function PlayerActionsMenu(
                 Edit
               </Label>
             </Box>
-            <MenuItem
-              icon={EditIcon}
-              text="Details"
-              onClick={() => setDialogState('edit-video')}
-            />
+            <MenuItem icon={EditIcon} text="Details" onClick={() => setDialogState('edit-video')} />
             <Box padding={2}>
               <Label muted size={1}>
                 Replace

--- a/src/components/UploadConfiguration.tsx
+++ b/src/components/UploadConfiguration.tsx
@@ -1,8 +1,8 @@
 import {DocumentVideoIcon, UploadIcon} from '@sanity/icons'
-import {Box, Button, Card, Checkbox, Dialog, Flex, Label, Radio, Stack, Text} from '@sanity/ui'
+import {Box, Button, Card, Checkbox, Dialog, Flex, Label, Radio, Stack, Text, TextInput} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import LanguagesList from 'iso-639-1'
-import {useEffect, useId, useReducer, useRef} from 'react'
+import {useEffect, useId, useReducer, useRef, useState} from 'react'
 import {FormField} from 'sanity'
 
 import formatBytes from '../util/formatBytes'
@@ -56,7 +56,7 @@ export default function UploadConfiguration({
   stagedUpload: StagedUpload
   secrets: Secrets
   pluginConfig: PluginConfig
-  startUpload: (settings: MuxNewAssetSettings) => void
+  startUpload: (settings: MuxNewAssetSettings, filename?: string) => void
   onClose: () => void
 }) {
   const id = useId()
@@ -140,14 +140,16 @@ export default function UploadConfiguration({
       text_tracks: autoTextTracks,
     } as UploadConfig
   )
+  const [filename, setFilename] = useState(stagedUpload.type === 'file' ? stagedUpload.files[0].name : undefined)
 
-  // If user-provided config is disabled, begin the upload immediately with
+  // If user-provided config is disabled,
+  // begin the upload immediately with
   // the developer-specified values from the schema or config or defaults.
   // This can include auto-generated subtitles!
   const {disableTextTrackConfig, disableUploadConfig} = pluginConfig
   const skipConfig = disableTextTrackConfig && disableUploadConfig
   useEffect(() => {
-    if (skipConfig) startUpload(formatUploadConfig(config))
+    if (skipConfig) startUpload(formatUploadConfig(config), filename)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   if (skipConfig) return null
@@ -177,9 +179,14 @@ export default function UploadConfiguration({
           <Flex gap={2}>
             <DocumentVideoIcon fontSize="2em" />
             <Stack space={2}>
-              <Text textOverflow="ellipsis" as="h2" size={3}>
-                {stagedUpload.type === 'file' ? stagedUpload.files[0].name : stagedUpload.url}
-              </Text>
+              {stagedUpload.type === 'file' ? (
+                <TextInput value={filename}
+                           onChange={(event) => setFilename(event.currentTarget.value)
+                }/>)
+                : (<Text textOverflow="ellipsis" as="h2" size={3}>
+              {stagedUpload.url}
+            </Text>)}
+
               <Text as="p" size={1} muted>
                 {stagedUpload.type === 'file'
                   ? `Direct File Upload (${formatBytes(stagedUpload.files[0].size)})`
@@ -343,7 +350,7 @@ export default function UploadConfiguration({
             icon={UploadIcon}
             text="Upload"
             tone="positive"
-            onClick={() => startUpload(formatUploadConfig(config))}
+            onClick={() => startUpload(formatUploadConfig(config), filename)}
           />
         </Box>
       </Stack>

--- a/src/components/UploadConfiguration.tsx
+++ b/src/components/UploadConfiguration.tsx
@@ -1,5 +1,17 @@
 import {DocumentVideoIcon, UploadIcon} from '@sanity/icons'
-import {Box, Button, Card, Checkbox, Dialog, Flex, Label, Radio, Stack, Text, TextInput} from '@sanity/ui'
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Dialog,
+  Flex,
+  Label,
+  Radio,
+  Stack,
+  Text,
+  TextInput,
+} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import LanguagesList from 'iso-639-1'
 import {useEffect, useId, useReducer, useRef, useState} from 'react'
@@ -140,7 +152,9 @@ export default function UploadConfiguration({
       text_tracks: autoTextTracks,
     } as UploadConfig
   )
-  const [filename, setFilename] = useState(stagedUpload.type === 'file' ? stagedUpload.files[0].name : undefined)
+  const [filename, setFilename] = useState(
+    stagedUpload.type === 'file' ? stagedUpload.files[0].name : undefined
+  )
 
   // If user-provided config is disabled,
   // begin the upload immediately with
@@ -180,12 +194,15 @@ export default function UploadConfiguration({
             <DocumentVideoIcon fontSize="2em" />
             <Stack space={2}>
               {stagedUpload.type === 'file' ? (
-                <TextInput value={filename}
-                           onChange={(event) => setFilename(event.currentTarget.value)
-                }/>)
-                : (<Text textOverflow="ellipsis" as="h2" size={3}>
-              {stagedUpload.url}
-            </Text>)}
+                <TextInput
+                  value={filename}
+                  onChange={(event) => setFilename(event.currentTarget.value)}
+                />
+              ) : (
+                <Text textOverflow="ellipsis" as="h2" size={3}>
+                  {stagedUpload.url}
+                </Text>
+              )}
 
               <Text as="p" size={1} muted>
                 {stagedUpload.type === 'file'

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -182,7 +182,7 @@ export default function Uploader(props: Props) {
           client: props.client,
           file: stagedUpload.files[0],
           settings,
-          filename
+          filename,
         }).pipe(
           takeUntil(
             cancelUploadButton.observable.pipe(
@@ -318,7 +318,7 @@ export default function Uploader(props: Props) {
       <UploadProgress
         onCancel={cancelUploadButton.handleClick}
         progress={uploadStatus.progress}
-        filename={uploadStatus.filename ||uploadStatus.file?.name || uploadStatus.url}
+        filename={uploadStatus.filename || uploadStatus.file?.name || uploadStatus.url}
       />
     )
   }
@@ -340,7 +340,6 @@ export default function Uploader(props: Props) {
   let tone: CardTone | undefined
   if (dragState) tone = dragState === 'valid' ? 'positive' : 'critical'
 
-
   return (
     <>
       <UploadCard
@@ -356,20 +355,20 @@ export default function Uploader(props: Props) {
           <Stack space={4}>
             <Text size={3}>{props.asset.filename}</Text>
             <Player
-            readOnly={props.readOnly}
-            asset={props.asset}
-            onChange={props.onChange}
-            buttons={
-              <PlayerActionsMenu
-                asset={props.asset}
-                dialogState={props.dialogState}
-                setDialogState={props.setDialogState}
-                onChange={props.onChange}
-                onSelect={handleUpload}
-                readOnly={props.readOnly}
-              />
-            }
-          />
+              readOnly={props.readOnly}
+              asset={props.asset}
+              onChange={props.onChange}
+              buttons={
+                <PlayerActionsMenu
+                  asset={props.asset}
+                  dialogState={props.dialogState}
+                  setDialogState={props.setDialogState}
+                  onChange={props.onChange}
+                  onSelect={handleUpload}
+                  readOnly={props.readOnly}
+                />
+              }
+            />
           </Stack>
         ) : (
           <UploadPlaceholder

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -387,7 +387,7 @@ export default function Uploader(props: Props) {
           setDialogState={props.setDialogState}
         />
       )}
-      {props.dialogState === 'edit-video' && props.asset != null && (
+      {props.dialogState === 'edit-video' && props.asset !== null && props.asset !== undefined && (
         <VideoDetails
           closeDialog={() => props.setDialogState(false)}
           asset={props.asset}

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -24,9 +24,7 @@ import UploadConfiguration from './UploadConfiguration'
 import {UploadCard} from './Uploader.styled'
 import UploadPlaceholder from './UploadPlaceholder'
 import {UploadProgress} from './UploadProgress'
-import FileNameForm from './FileNameForm'
 import VideoDetails from './VideoDetails/VideoDetails'
-import FormField from './FormField'
 
 interface Props extends Pick<MuxInputProps, 'onChange' | 'readOnly'> {
   config: PluginConfig

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -1,5 +1,5 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
-import {Button, CardTone, Flex, Text, useToast} from '@sanity/ui'
+import {Button, CardTone, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
 import React, {useEffect, useReducer, useRef, useState} from 'react'
 import {type Observable, Subject, Subscription} from 'rxjs'
 import {takeUntil, tap} from 'rxjs/operators'
@@ -24,6 +24,9 @@ import UploadConfiguration from './UploadConfiguration'
 import {UploadCard} from './Uploader.styled'
 import UploadPlaceholder from './UploadPlaceholder'
 import {UploadProgress} from './UploadProgress'
+import FileNameForm from './FileNameForm'
+import VideoDetails from './VideoDetails/VideoDetails'
+import FormField from './FormField'
 
 interface Props extends Pick<MuxInputProps, 'onChange' | 'readOnly'> {
   config: PluginConfig
@@ -41,6 +44,7 @@ type UploadStatus = {
   file?: {name: string | undefined; type: string}
   uuid?: string
   url?: string
+  filename?: string
 }
 
 interface State {
@@ -159,7 +163,7 @@ export default function Uploader(props: Props) {
    * @param settings The Mux new_asset_settings object to send to Sanity
    * @returns
    */
-  const startUpload = (settings: MuxNewAssetSettings) => {
+  const startUpload = (settings: MuxNewAssetSettings, filename?: string) => {
     const {stagedUpload} = state
     if (!stagedUpload || uploadRef.current) return
     dispatch({action: 'commitUpload'})
@@ -178,6 +182,7 @@ export default function Uploader(props: Props) {
           client: props.client,
           file: stagedUpload.files[0],
           settings,
+          filename
         }).pipe(
           takeUntil(
             cancelUploadButton.observable.pipe(
@@ -313,7 +318,7 @@ export default function Uploader(props: Props) {
       <UploadProgress
         onCancel={cancelUploadButton.handleClick}
         progress={uploadStatus.progress}
-        filename={uploadStatus.file?.name || uploadStatus.url}
+        filename={uploadStatus.filename ||uploadStatus.file?.name || uploadStatus.url}
       />
     )
   }
@@ -335,6 +340,7 @@ export default function Uploader(props: Props) {
   let tone: CardTone | undefined
   if (dragState) tone = dragState === 'valid' ? 'positive' : 'critical'
 
+
   return (
     <>
       <UploadCard
@@ -347,7 +353,9 @@ export default function Uploader(props: Props) {
         ref={containerRef}
       >
         {props.asset ? (
-          <Player
+          <Stack space={4}>
+            <Text size={3}>{props.asset.filename}</Text>
+            <Player
             readOnly={props.readOnly}
             asset={props.asset}
             onChange={props.onChange}
@@ -362,6 +370,7 @@ export default function Uploader(props: Props) {
               />
             }
           />
+          </Stack>
         ) : (
           <UploadPlaceholder
             hovering={dragState !== null}
@@ -377,6 +386,13 @@ export default function Uploader(props: Props) {
           asset={props.asset}
           onChange={props.onChange}
           setDialogState={props.setDialogState}
+        />
+      )}
+      {props.dialogState === 'edit-video' && props.asset != null && (
+        <VideoDetails
+          closeDialog={() => props.setDialogState(false)}
+          asset={props.asset}
+          placement="input"
         />
       )}
     </>

--- a/src/hooks/useDialogState.ts
+++ b/src/hooks/useDialogState.ts
@@ -2,7 +2,7 @@
 
 import {useState} from 'react'
 
-export type DialogState = 'secrets' | 'select-video' | 'edit-thumbnail' | false
+export type DialogState = 'secrets' | 'select-video' | 'edit-video' | 'edit-thumbnail' | false
 
 export function useDialogState() {
   return useState<DialogState>(false)


### PR DESCRIPTION
This PR adds a TextField to the UploadConfiguration dialog presented when uploading a file, where the user can customize the filename which is stored in Sanity.
<img width="665" alt="Screenshot 2024-10-08 at 18 11 31" src="https://github.com/user-attachments/assets/5b376e8e-d46e-49ce-85fb-666eba436124">

It also adds a new menu item for video previews in the input for Mux videos to edit the video:
<img width="684" alt="Screenshot 2024-10-08 at 18 11 14" src="https://github.com/user-attachments/assets/1644a144-ceb2-44fd-9315-ac3823801cbe">
